### PR TITLE
Add convoy feature

### DIFF
--- a/industry.lua
+++ b/industry.lua
@@ -3,22 +3,29 @@
 if (industry ~= nil) then return 0 end
 industry = {}
 
-industry.ressources = {red = 0, blue = 0}
+industry.ressources = {red = 200, blue = 200}
 industry.factories = {red= 1, blue = 1}
 industry.storages = {red= 1, blue = 1}
 
+function industry.destroy(gpName)
+    local _group = Group.getByName(gpName)
+    Group.destroy(_group)
+end
+
 function industry.respawn(gpName, costs)
     local groupdata = mist.getGroupData(gpName)
-    
-    if (groupdata.coalition == 1) then
+
+    if (groupdata.coalition == "red") then
         if industry.ressources.red >= costs then
             industry.ressources.red = industry.ressources.red - costs
             mist.respawnGroup(gpName, true)
+            trigger.action.outText(string.format("Respawned group %s for %d tons of RED ressources", gpName, costs), 10)
         end
     else
         if industry.ressources.blue >= costs then
             industry.ressources.blue = industry.ressources.blue - costs
             mist.respawnGroup(gpName, true)
+            trigger.action.outText(string.format("Respawned group %s for %d tons of BLUE ressources", gpName, costs), 10)
         end
     end
 end
@@ -30,23 +37,46 @@ function industry.addRessources(coalition, tons)
         industry.ressources.blue = industry.ressources.blue + tons
     end
 
-    trigger.action.outText(string.format("A %s transport with %d tons of ressources arrived its destination", coalition, tons), 10)
+    trigger.action.outText(string.format("A %s transport with %d tons of ressources arrived at its destination", coalition, tons), 5)
+end
+
+function industry.addRessourcesConvoy(groupName, truckTypeName, tonsEach)
+    local _group = Group.getByName(groupName)
+    local _addRessources = 0
+
+    trigger.action.outText(string.format("Coalition:%d Name:%s", _group:getCoalition(), _group:getName()), 15)
+
+    -- not using Group.getUnits() due to DCS bug with some unit types
+    for i=1,_group:getSize() do
+        local _unit = _group:getUnit(i)
+        env.info(string.format("Convoy unit %d arrived: %s (%s)", i, _unit:getName(), _unit:getTypeName()), false)
+        if (string.match(_unit:getTypeName(), truckTypeName) and _unit:getLife() > 1) then
+            _addRessources = _addRessources + tonsEach
+        end
+    end
+
+    if (_group:getCoalition() == 1) then
+        industry.ressources.red = industry.ressources.red + _addRessources
+        trigger.action.outText(string.format("A RED convoy with %d tons of ressources arrived at its destination", _addRessources), 5)
+    else
+        industry.ressources.blue = industry.ressources.blue + _addRessources
+        trigger.action.outText(string.format("A BLUE convoy with %d tons of ressources arrived at its destination", _addRessources), 5)
+    end
 end
 
 function industry.destroyStorage(coalition)
     if (string.match(coalition, "RED") and industry.storages.red > 0) then
-        trigger.action.outText(string.format("RED had %d storages and %d tons ressources", industry.storages.red, industry.ressources.red), 10)   
         industry.ressources.red = industry.ressources.red - math.floor(industry.ressources.red / industry.storages.red)
         industry.storages.red = industry.storages.red - 1
 
-        trigger.action.outText(string.format("A RED storage has been destroyed. %d tons ressources left", industry.ressources.red), 10)   
+        trigger.action.outText(string.format("A RED storage has been destroyed. %d tons ressources left", industry.ressources.red), 5)   
     end
 
     if (string.match(coalition, "BLUE") and industry.storages.blue > 0) then
         industry.ressources.blue = industry.ressources.blue - math.floor(industry.ressources.blue / industry.storages.blue)
         industry.storages.blue = industry.storages.blue - 1
 
-        trigger.action.outText(string.format("A RED storage has been destroyed. %d tons ressources left", industry.ressources.red), 10)   
+        trigger.action.outText(string.format("A RED storage has been destroyed. %d tons ressources left", industry.ressources.red), 5)   
     end
 end
 
@@ -108,10 +138,6 @@ function industry.loop()
     trigger.action.outText(string.format("BLUE (%d/%d): %d tons    RED (%d/%d): %d tons", industry.factories.blue, industry.storages.blue, industry.ressources.blue, industry.factories.red, industry.storages.red, industry.ressources.red), 10)
 end
 
-mist.scheduleFunction(industry.loop,{} , timer.getTime() + 10, 30)
-
-industry.statics = coalition.getStaticObjects(1)
-
-industry.loop()
+mist.scheduleFunction(industry.loop,{} , timer.getTime() + 1, 300)
 
 env.info("Industry script initialized")


### PR DESCRIPTION
Only units of name X are counted as successful delivery of ressources

Fix lots of bugs
Add feature to destroy groups (needed for "group dead" respawn via MIST sometimes) Fix bug where costs were always put on blue coalition Removed unused code
added 200 tons of ressources as start budget