### PR TITLE
SAR Missions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ industry.config.checkDeadGroupsTime = 300
 industry.config.respawnRetriesOnQueue = 2
 industry.config.winCountdownLength = 600
 industry.config.tickets = 100
+industry.config.ticketsLow = 20
 ```
 
 #### industry.config.startRessources
@@ -232,6 +233,15 @@ blueStorageDestroyed // if it was a blue storage that got destroyed
 ```
 
 In the class type triggers do not forget the flag back to false or 0 after it got handled in the editor so it can be handled multiple times (if needed).
+
+### Threshold for tickets
+If the tickets of one side run below a threshold a corresponding trigger ("ticketsLowBlue" or "ticketsLowRed") is set to true. You can use this trigger to switch events in your custom mission.
+
+The threshold is configured by the variable
+```
+industry.config.ticketsLow = 20 // default
+```
+and can be set in your config.
 
 ### Plane landed
 If a plane landed and shut down its engines a flag with the name

--- a/industry.lua
+++ b/industry.lua
@@ -14,6 +14,7 @@ industry.config = {
     respawnRetriesOnQueue = 2,
     winCountdownLength = 600,
     tickets = 100,
+    ticketsLow = 20,
 }
 
 industry.version = "v0.10.1"
@@ -484,6 +485,14 @@ function industry.evaluateTicketWinner()
                 industry.winMission(coalition.side.NEUTRAL)
             end
         end
+    end
+
+    if (industry.tickets[coalition.side.RED] <= industry.config.ticketsLow) then
+        trigger.action.setUserFlag('ticketsLowRed', true)
+    end
+
+    if (industry.tickets[coalition.side.BLUE] <= industry.config.ticketsLow) then
+        trigger.action.setUserFlag('ticketsLowBlue', true)
     end
 end
 


### PR DESCRIPTION
- Autospawn a SAR mission if a pilot parachute touches down
- Add a trigger 'ticketsLowBlue' and 'ticketsLowRed' that is set to true if tickets of the respective side run under a threshold to trigger events in the mission